### PR TITLE
Add timeout to query

### DIFF
--- a/pyHS100/protocol.py
+++ b/pyHS100/protocol.py
@@ -39,20 +39,23 @@ class TPLinkSmartHomeProtocol:
             request = json.dumps(request)
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        sock.connect((host, port))
+        sock.settimeout(5.0)
+        try:
+            sock.connect((host, port))
 
-        _LOGGER.debug("> (%i) %s", len(request), request)
-        sock.send(TPLinkSmartHomeProtocol.encrypt(request))
+            _LOGGER.debug("> (%i) %s", len(request), request)
+            sock.send(TPLinkSmartHomeProtocol.encrypt(request))
 
-        buffer = bytes()
-        while True:
-            chunk = sock.recv(4096)
-            buffer += chunk
-            if not chunk:
-                break
+            buffer = bytes()
+            while True:
+                chunk = sock.recv(4096)
+                buffer += chunk
+                if not chunk:
+                    break
 
-        sock.shutdown(socket.SHUT_RDWR)
-        sock.close()
+        finally:
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.close()
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
         _LOGGER.debug("< (%i) %s", len(response), response)

--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -103,7 +103,7 @@ class SmartPlug:
                 request={target: {cmd: arg}}
             )
         except Exception as ex:
-            raise SmartPlugException(ex)
+            raise SmartPlugException(ex) from ex
 
         result = response[target]
         if "err_code" in result and result["err_code"] != 0:


### PR DESCRIPTION
Add a timeout to the socket; should help home-assistant and others avoid hanging during startup.

I haven't tried this in home-assistant, but I've tried it in the example CLI and I get:

```
$ python3 examples/cli.py 192.168.1.105
DEBUG:pyHS100.protocol:> (31) {"system": {"get_sysinfo": {}}}
Traceback (most recent call last):
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 103, in _query_helper
    request={target: {cmd: arg}}
  File "/home/hendrix/home/pyHS100/pyHS100/protocol.py", line 51, in query
    chunk = sock.recv(4096)
socket.timeout: timed out

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "examples/cli.py", line 15, in <module>
    logging.info("Identify: %s", hs.identify())
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 327, in identify
    return self.alias, self.model, self.features
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 365, in alias
    return self.sys_info['alias']
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 120, in sys_info
    self._fetch_sysinfo()
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 86, in _fetch_sysinfo
    self._sys_info = self.get_sysinfo()
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 176, in get_sysinfo
    return self._query_helper("system", "get_sysinfo")
  File "/home/hendrix/home/pyHS100/pyHS100/pyHS100.py", line 106, in _query_helper
    raise SmartPlugException(ex) from ex
pyHS100.pyHS100.SmartPlugException: timed out
```