### PR TITLE
allow manual updates of the smartplug state

### DIFF
--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -75,16 +75,6 @@ class SmartPlug:
         self.protocol = protocol
         self._sys_info = None
 
-    def _fetch_sysinfo(self):
-        """
-        Fetches the system information from the device.
-
-        This should be called when the state of the plug is changed.
-
-        :raises: SmartPlugException: on error
-        """
-        self._sys_info = self.get_sysinfo()
-
     def _query_helper(self, target, cmd, arg={}):
         """
         Helper returning unwrapped result object and doing error handling.
@@ -114,10 +104,20 @@ class SmartPlug:
 
         return result
 
+    def update(self):
+        """
+        Fetches the system information from the device.
+
+        This should be called when the state of the plug is changed.
+
+        :raises: SmartPlugException: on error
+        """
+        self._sys_info = self.get_sysinfo()
+
     @property
     def sys_info(self):
         if not self._sys_info:
-            self._fetch_sysinfo()
+            self.update()
 
         return self._sys_info
 
@@ -163,7 +163,7 @@ class SmartPlug:
         else:
             raise ValueError("State %s is not valid.", value)
 
-        self._fetch_sysinfo()
+        self.update()
 
     def get_sysinfo(self):
         """
@@ -202,7 +202,7 @@ class SmartPlug:
         """
         self._query_helper("system", "set_relay_state", {"state": 1})
 
-        self._fetch_sysinfo()
+        self.update()
 
     def turn_off(self):
         """
@@ -212,7 +212,7 @@ class SmartPlug:
         """
         self._query_helper("system", "set_relay_state", {"state": 0})
 
-        self._fetch_sysinfo()
+        self.update()
 
     @property
     def has_emeter(self):
@@ -297,7 +297,7 @@ class SmartPlug:
 
         self._query_helper("emeter", "erase_emeter_stat", None)
 
-        self._fetch_sysinfo()
+        self.update()
 
         # As query_helper raises exception in case of failure, we have succeeded when we are this far.
         return True
@@ -374,7 +374,7 @@ class SmartPlug:
         """
         self._query_helper("system", "set_dev_alias", {"alias": alias})
 
-        self._fetch_sysinfo()
+        self.update()
 
     @property
     def led(self):
@@ -396,7 +396,7 @@ class SmartPlug:
         """
         self._query_helper("system", "set_led_off", {"off": int(not state)})
 
-        self._fetch_sysinfo()
+        self.update()
 
     @property
     def icon(self):
@@ -544,7 +544,7 @@ class SmartPlug:
         """
         self._query_helper("system", "set_mac_addr", {"mac": mac})
 
-        self._fetch_sysinfo()
+        self.update()
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pyHS100',
-      version='0.2.2',
+      version='0.2.3',
       description='Interface for TPLink HS100 Smart Plugs.',
       url='https://github.com/GadgetReactor/pyHS100',
       author='Sean Seah (GadgetReactor)',


### PR DESCRIPTION
Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>

The home-assistant bindings want to update the smartplug state in intervals, since there are other applications that could interact with the smartplug.

Let's make the method public and call it aptly `update`.

Also bump version to 0.2.3, since this warrants a quick update to roll out to all homeassistant users.

references:
https://github.com/home-assistant/home-assistant/issues/4992
https://github.com/home-assistant/home-assistant/pull/4914