### PR TITLE
Ignore error when closing read side of socket after closing write side

### DIFF
--- a/pyHS100/protocol.py
+++ b/pyHS100/protocol.py
@@ -53,9 +53,10 @@ class TPLinkSmartHomeProtocol:
 
         try:
             sock.shutdown(socket.SHUT_RDWR)
-            sock.close()
-        except:
+        except OSError:
             pass
+        finally:
+            sock.close()
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
         _LOGGER.debug("< (%i) %s", len(response), response)

--- a/pyHS100/protocol.py
+++ b/pyHS100/protocol.py
@@ -51,8 +51,11 @@ class TPLinkSmartHomeProtocol:
             if not chunk:
                 break
 
-        sock.shutdown(socket.SHUT_RDWR)
-        sock.close()
+        try:
+            sock.shutdown(socket.SHUT_RDWR)
+            sock.close()
+        except:
+            pass
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
         _LOGGER.debug("< (%i) %s", len(response), response)


### PR DESCRIPTION
On Mac OS X, shutdown(SHUT_RD) fails if the write side on the other side has been closed.