### PR TITLE
set color temp to 0 when trying to change color

### DIFF
--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -507,6 +507,7 @@ class SmartBulb(SmartDevice):
             "hue": state[0],
             "saturation": state[1],
             "brightness": int(state[2] * 100 / 255),
+			"color_temp": 0
             }
         return self.set_light_state(light_state)
 

--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -507,7 +507,7 @@ class SmartBulb(SmartDevice):
             "hue": state[0],
             "saturation": state[1],
             "brightness": int(state[2] * 100 / 255),
-			"color_temp": 0
+            "color_temp": 0
             }
         return self.set_light_state(light_state)
 


### PR DESCRIPTION
Attempting to change the hsv while a bulb is currently using a non-zero white color temp results in the values being set but they don't take. Color temp appears to take precedence unless it is 0. By setting color temp to 0 every time hsv is set it should take. I say "should" as I discovered this while translating to perl and haven't tested it in python. Once I got it working in perl I wondered how I missed it and I noticed you didn't have it.