### PR TITLE
Ignore OSError on socket.shutdown()

### DIFF
--- a/pyHS100/protocol.py
+++ b/pyHS100/protocol.py
@@ -63,8 +63,14 @@ class TPLinkSmartHomeProtocol:
                     break
 
         finally:
-            sock.shutdown(socket.SHUT_RDWR)
-            sock.close()
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+                sock.close()
+            except OSError:
+                # OSX raises OSError when shutdown() gets called on a closed
+                # socket. We ignore it here as the data has already been read
+                # into the buffer at this point.
+                pass
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
         _LOGGER.debug("< (%i) %s", len(response), response)


### PR DESCRIPTION
This fixes #22 and obsoletes PR #23.