### PR TITLE
add future requirement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,12 @@
 Changelog
 =========
 
+0.2.4.2 (2017-04-08)
+--------------------
+- Add installation requirement for future package. [Teemu Rytilahti]
+
 0.2.4.1 (2017-03-26)
-------------
+--------------------
 - Cli: display an error if no ip is given. [Teemu Rytilahti]
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 from setuptools import setup
 
 setup(name='pyHS100',
-      version='0.2.4.1',
+      version='0.2.4.2',
       description='Interface for TPLink HS100 Smart Plugs.',
       url='https://github.com/GadgetReactor/pyHS100',
       author='Sean Seah (GadgetReactor)',
       author_email='sean@gadgetreactor.com',
       license='GPLv3',
       packages=['pyHS100'],
-      install_requires=['click', 'click-datetime'],
+      install_requires=['click', 'click-datetime', 'future'],
       entry_points={
             'console_scripts': [
                   'pyhs100=pyHS100.cli:cli',


### PR DESCRIPTION
Due to the current python2 compatibility we are using raise_from from future, which was not marked as a requirement for this package, causing failure to function as seen in #46 . This fixes that, although we should really consider deprecating the python2 support completely.