### PR TITLE
If latitude/longitude not set, return None entries

### DIFF
--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -291,8 +291,12 @@ class SmartDevice(object):
         :rtype: dict
         """
         info = self.sys_info
-        return {"latitude": info["latitude"],
-                "longitude": info["longitude"]}
+        if ("latitude" in info and "longitude" in info):
+            return {"latitude": info["latitude"],
+                    "longitude": info["longitude"]}
+        else:
+            return {"latitude": "N/A",
+                    "longitude": "N/A"}
 
     @property
     def rssi(self):

--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -295,8 +295,8 @@ class SmartDevice(object):
             return {"latitude": info["latitude"],
                     "longitude": info["longitude"]}
         else:
-            return {"latitude": "N/A",
-                    "longitude": "N/A"}
+            return {"latitude": None,
+                    "longitude": None}
 
     @property
     def rssi(self):


### PR DESCRIPTION
When lat/long have not been set up, sysinfo shows latitude_i and longitude_i set to 0, and there is
no entry for latitude or longitude
Previous to this fix, that would cause an exception:

```
Traceback (most recent call last):
  File "/usr/local/bin/pyhs100", line 11, in <module>
    sys.exit(cli())
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/decorators.py", line 64, in new_func
    return ctx.invoke(f, obj, *args[1:], **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/pyHS100/cli.py", line 70, in state
    click.echo("Location:     %s" % plug.location)
  File "/usr/local/lib/python2.7/dist-packages/pyHS100/pyHS100.py", line 251, in location
    return {"latitude": info["latitude"],
KeyError: u'latitude'
```

This fixes that, and returns "N/A" in the dict entry instead