### PR TITLE
[SmartDevice] - Bugfix - Adds LB100 support for getting and setting the mac address

### DIFF
--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -323,9 +323,8 @@ class SmartDevice(object):
         :return: mac address in hexadecimal with colons, e.g. 01:23:45:67:89:ab
         :rtype: str
         """
-
         info = self.sys_info
-        
+
         if 'mac' in info:
             return info["mac"]
         elif 'mic_mac' in info:

--- a/pyHS100/pyHS100.py
+++ b/pyHS100/pyHS100.py
@@ -323,7 +323,16 @@ class SmartDevice(object):
         :return: mac address in hexadecimal with colons, e.g. 01:23:45:67:89:ab
         :rtype: str
         """
-        return self.sys_info["mac"]
+
+        info = self.sys_info
+        
+        if 'mac' in info:
+            return info["mac"]
+        elif 'mic_mac' in info:
+            return info['mic_mac']
+        else:
+            _LOGGER.warning("Unsupported device mac.")
+            return ''
 
     @mac.setter
     def mac(self, mac):
@@ -333,7 +342,18 @@ class SmartDevice(object):
         :param str mac: mac in hexadecimal with colons, e.g. 01:23:45:67:89:ab
         :raises SmartPlugException: on error
         """
-        self._query_helper("system", "set_mac_addr", {"mac": mac})
+        info = self.sys_info
+
+        if 'mac' in info:
+            self._query_helper("system", "set_mac_addr", {"mac": mac})
+        elif 'mic_mac' in info:
+            self._query_helper(
+                "system",
+                "set_mac_addr",
+                {"mic_mac": mac.replace(':', '')}
+            )
+        else:
+            _LOGGER.warning("Unsupported device mac.")
 
     def get_emeter_realtime(self):
         """


### PR DESCRIPTION
LB100 devices instead of using 'mac' as a keyword they use 'mic_mac' so checking for the keyword has been added to the getter and setter