### PR TITLE
Extend tests

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -9,8 +9,10 @@ if sys.version_info < (3, 4):
           sys.version_info)
     sys.exit(1)
 
-from pyHS100 import (SmartDevice, SmartPlug, SmartBulb,
-                     TPLinkSmartHomeProtocol, Discover)  # noqa: E402
+from pyHS100 import (SmartDevice,
+                     SmartPlug,
+                     SmartBulb,
+                     Discover)  # noqa: E402
 
 pass_dev = click.make_pass_decorator(SmartDevice)
 

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -338,12 +338,12 @@ class SmartDevice(object):
         Retrive current energy readings from device.
 
         :returns: current readings or False
-        :rtype: dict, False
-                  False if device has no energy meter or error occured
+        :rtype: dict, None
+                  None if device has no energy meter or error occured
         :raises SmartDeviceException: on error
         """
         if not self.has_emeter:
-            return False
+            return None
 
         return self._query_helper(self.emeter_type, "get_realtime")
 
@@ -355,12 +355,12 @@ class SmartDevice(object):
         :param month: month for which to retrieve statistcs (default: this
                       month)
         :return: mapping of day of month to value
-                 False if device has no energy meter or error occured
+                 None if device has no energy meter or error occured
         :rtype: dict
         :raises SmartDeviceException: on error
         """
         if not self.has_emeter:
-            return False
+            return None
 
         if year is None:
             year = datetime.datetime.now().year
@@ -384,12 +384,12 @@ class SmartDevice(object):
 
         :param year: year for which to retrieve statistics (default: this year)
         :return: dict: mapping of month to value
-                 False if device has no energy meter
+                 None if device has no energy meter
         :rtype: dict
         :raises SmartDeviceException: on error
         """
         if not self.has_emeter:
-            return False
+            return None
 
         response = self._query_helper(self.emeter_type, "get_monthstat",
                                       {'year': year})
@@ -412,7 +412,7 @@ class SmartDevice(object):
         :raises SmartDeviceException: on error
         """
         if not self.has_emeter:
-            return False
+            return None
 
         self._query_helper(self.emeter_type, "erase_emeter_stat", None)
 
@@ -425,11 +425,11 @@ class SmartDevice(object):
         Get the current power consumption in Watt.
 
         :return: the current power consumption in Watt.
-                 False if device has no energy meter.
+                 None if device has no energy meter.
         :raises SmartDeviceException: on error
         """
         if not self.has_emeter:
-            return False
+            return None
 
         response = self.get_emeter_realtime()
         if self.emeter_units:

--- a/pyHS100/tests/fakes.py
+++ b/pyHS100/tests/fakes.py
@@ -265,6 +265,7 @@ sysinfo_lb110 = {'system': {
          }
 }}
 
+
 def error(cls, target, cmd="no-command", msg="default msg"):
     return {target: {cmd: {"err_code": -1323, "msg": msg}}}
 

--- a/pyHS100/tests/fakes.py
+++ b/pyHS100/tests/fakes.py
@@ -71,7 +71,7 @@ sysinfo_hs105 = {'system': {'get_sysinfo':
                             {'sw_ver': '1.0.6 Build 160722 Rel.081616',
                              'hw_ver': '1.0', 'type': 'IOT.SMARTPLUGSWITCH',
                              'model': 'HS105(US)',
-                             'mac': '50:C7:BF:xx:xx:xx',
+                             'mac': '50:C7:BF:11:22:33',
                              'dev_name': 'Smart Wi-Fi Plug Mini',
                              'alias': 'TP-LINK_Smart Plug_CF0B',
                              'relay_state': 0,
@@ -198,70 +198,72 @@ sysinfo_lb130 = {'system': {'get_sysinfo':
                  'smartlife.iot.common.emeter': emeter_units_support,
 }
 
-sysinfo_lb110 = {'sys_info': {'emeter':
-                              {'err_code': -2001,
-                               'err_msg': 'Module not support'},
-                              'system':
-                              {'get_sysinfo':
-                               {'active_mode': 'schedule',
-                                'alias': 'Downstairs Light',
-                                'ctrl_protocols':
-                                {'name': 'Linkie',
-                                 'version': '1.0'},
-                                'description': 'Smart Wi-Fi LED Bulb '
-                                               'with Dimmable Light',
-                                'dev_state': 'normal',
-                                'deviceId':
-                                    '80120B3D03E0B639CDF33E3CB1466490187FEF32',
-                                'disco_ver': '1.0',
-                                'err_code': 0,
-                                'heapsize': 309908,
-                                'hwId': '111E35908497A05512E259BB76801E10',
-                                'hw_ver': '1.0',
-                                'is_color': 0,
-                                'is_dimmable': 1,
-                                'is_factory': False,
-                                'is_variable_color_temp': 0,
-                                'light_state':
-                                {'dft_on_state':
-                                 {'brightness': 92,
-                                  'color_temp': 2700,
-                                  'hue': 0,
-                                  'mode': 'normal',
-                                  'saturation': 0},
-                                 'on_off': 0},
-                                'mic_mac': '50C7BF7BE306',
-                                'mic_type': 'IOT.SMARTBULB',
-                                'model': 'LB110(EU)',
-                                'oemId':
-                                    'A68E15472071CB761E5CCFB388A1D8AE',
-                                'preferred_state': [{'brightness': 100,
-                                                     'color_temp': 2700,
-                                                     'hue': 0,
-                                                     'index': 0,
-                                                     'saturation': 0},
-                                                    {'brightness': 58,
-                                                     'color_temp': 2700,
-                                                     'hue': 0,
-                                                     'index': 1,
-                                                     'saturation': 0},
-                                                    {'brightness': 25,
-                                                     'color_temp': 2700,
-                                                     'hue': 0,
-                                                     'index': 2,
-                                                     'saturation': 0},
-                                                    {'brightness': 1,
-                                                     'color_temp': 2700,
-                                                     'hue': 0,
-                                                     'index': 3,
-                                                     'saturation': 0}],
-                                'rssi': -61,
-                                'sw_ver': '1.5.5 Build 170623 '
-                                          'Rel.090105'
-                               }
-                              }
-                             }
-                }
+sysinfo_lb110 = {'system': {
+    'sys_info':
+        {'emeter':
+             {'err_code': -2001,
+              'err_msg': 'Module not support'},
+         'system':
+             {'get_sysinfo':
+                  {'active_mode': 'schedule',
+                   'alias': 'Downstairs Light',
+                   'ctrl_protocols':
+                       {'name': 'Linkie',
+                        'version': '1.0'},
+                   'description': 'Smart Wi-Fi LED Bulb '
+                                  'with Dimmable Light',
+                   'dev_state': 'normal',
+                   'deviceId':
+                       '80120B3D03E0B639CDF33E3CB1466490187FEF32',
+                   'disco_ver': '1.0',
+                   'err_code': 0,
+                   'heapsize': 309908,
+                   'hwId': '111E35908497A05512E259BB76801E10',
+                   'hw_ver': '1.0',
+                   'is_color': 0,
+                   'is_dimmable': 1,
+                   'is_factory': False,
+                   'is_variable_color_temp': 0,
+                   'light_state':
+                       {'dft_on_state':
+                            {'brightness': 92,
+                             'color_temp': 2700,
+                             'hue': 0,
+                             'mode': 'normal',
+                             'saturation': 0},
+                        'on_off': 0},
+                   'mic_mac': '50C7BF7BE306',
+                   'mic_type': 'IOT.SMARTBULB',
+                   'model': 'LB110(EU)',
+                   'oemId':
+                       'A68E15472071CB761E5CCFB388A1D8AE',
+                   'preferred_state': [{'brightness': 100,
+                                        'color_temp': 2700,
+                                        'hue': 0,
+                                        'index': 0,
+                                        'saturation': 0},
+                                       {'brightness': 58,
+                                        'color_temp': 2700,
+                                        'hue': 0,
+                                        'index': 1,
+                                        'saturation': 0},
+                                       {'brightness': 25,
+                                        'color_temp': 2700,
+                                        'hue': 0,
+                                        'index': 2,
+                                        'saturation': 0},
+                                       {'brightness': 1,
+                                        'color_temp': 2700,
+                                        'hue': 0,
+                                        'index': 3,
+                                        'saturation': 0}],
+                   'rssi': -61,
+                   'sw_ver': '1.5.5 Build 170623 '
+                             'Rel.090105'
+                   }
+              }
+         }
+}}
 
 def error(cls, target, cmd="no-command", msg="default msg"):
     return {target: {cmd: {"err_code": -1323, "msg": msg}}}

--- a/pyHS100/tests/fakes.py
+++ b/pyHS100/tests/fakes.py
@@ -58,7 +58,7 @@ sysinfo_hs100 = {'system': {'get_sysinfo':
                                  'latitude': 12.2,
                                  'led_off': 0,
                                  'longitude': 12.2,
-                                 'mac': '50:C7:BF:xx:xx:xx',
+                                 'mac': '50:C7:BF:11:22:33',
                                  'model': 'HS100(EU)',
                                  'oemId': '812A90EB2FCF306A993FAD8748024B07',
                                  'on_time': 255419,

--- a/pyHS100/tests/test_bulb.py
+++ b/pyHS100/tests/test_bulb.py
@@ -3,7 +3,7 @@ from voluptuous import Schema, Invalid, All, Range
 from functools import partial
 
 from .. import SmartBulb, SmartDeviceException
-from .fakes import FakeTransportProtocol, sysinfo_lb130
+from .fakes import FakeTransportProtocol, sysinfo_lb130, sysinfo_lb110
 
 BULB_IP = '192.168.250.186'
 SKIP_STATE_TESTS = False
@@ -23,6 +23,7 @@ def check_mode(x):
 
 
 class TestSmartBulb(TestCase):
+    SYSINFO = sysinfo_lb130
     # these schemas should go to the mainlib as
     # they can be useful when adding support for new features/devices
     # as well as to check that faked devices are operating properly.
@@ -80,7 +81,7 @@ class TestSmartBulb(TestCase):
 
     def setUp(self):
         self.bulb = SmartBulb(BULB_IP,
-                              protocol=FakeTransportProtocol(sysinfo_lb130))
+                              protocol=FakeTransportProtocol(self.SYSINFO))
 
     def tearDown(self):
         self.bulb = None
@@ -91,7 +92,7 @@ class TestSmartBulb(TestCase):
 
     def test_initialize_invalid_connection(self):
         bulb = SmartBulb('127.0.0.1',
-                         protocol=FakeTransportProtocol(sysinfo_lb130,
+                         protocol=FakeTransportProtocol(self.SYSINFO,
                                                         invalid=True))
         with self.assertRaises(SmartDeviceException):
             bulb.sys_info['model']
@@ -187,3 +188,7 @@ class TestSmartBulb(TestCase):
 
     def test_rssi(self):
         self.sysinfo_schema({'rssi': self.bulb.rssi})  # wrapping for vol
+
+
+class TestSmartBulbLB110(TestSmartBulb):
+    SYSINFO = sysinfo_lb110

--- a/pyHS100/tests/test_pyHS100.py
+++ b/pyHS100/tests/test_pyHS100.py
@@ -6,8 +6,9 @@ import re
 
 from .. import SmartPlug, SmartDeviceException
 from .fakes import (FakeTransportProtocol,
-                    sysinfo_hs110,
+                    sysinfo_hs100,
                     sysinfo_hs105,
+                    sysinfo_hs110,
                     sysinfo_hs200)
 
 PLUG_IP = '192.168.250.186'
@@ -248,6 +249,10 @@ class TestSmartPlugHS110(TestCase):
     def test_mac(self):
         self.sysinfo_schema({'mac': self.plug.mac})  # wrapping for val
         # TODO check setting?
+
+
+class TestSmartPlugHS100(TestSmartPlugHS110):
+    SYSINFO = sysinfo_hs100
 
 
 class TestSmartPlugHS200(TestSmartPlugHS110):

--- a/pyHS100/tests/test_pyHS100.py
+++ b/pyHS100/tests/test_pyHS100.py
@@ -59,7 +59,7 @@ class TestSmartPlugHS110(TestCase):
         'oemId': str,
         'on_time': int,
         'relay_state': int,
-        'rssi': int,  # apparently rssi can also be positive, see #54
+        'rssi': Any(int, None),  # rssi can also be positive, see #54
         'sw_ver': str,
         'type': str,
         'mic_type': str,


### PR DESCRIPTION
Run the tests against all known system infos (HS100, HS105, HS110, HS200, LB110, LB130). The error with 'rssi' will be fixed when #72 gets merged.

Also change the API for meter-based functionalities, they will now return None instead of False when the device has no emeter.