### PR TITLE
move has_emeter implementation from SmartDevice to SmartPlug, avoid using features() internally

### DIFF
--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -99,7 +99,8 @@ class SmartDevice(object):
         warnings.warn(
             "features works only on plugs and its use is discouraged, "
             "and it will likely to be removed at some point",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         warnings.simplefilter('default', DeprecationWarning)
         if "feature" not in self.sys_info:
@@ -155,7 +156,8 @@ class SmartDevice(object):
         warnings.simplefilter('always', DeprecationWarning)
         warnings.warn(
             "use alias and model instead of idenfity()",
-            DeprecationWarning
+            DeprecationWarning,
+            stacklevel=2
         )
         warnings.simplefilter('default', DeprecationWarning)
 

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -117,12 +117,13 @@ class SmartDevice(object):
     @property
     def has_emeter(self) -> bool:
         """
-        Checks feature list for energey meter support.
+        Checks feature list for energy meter support.
+        Note: this has to be implemented on a device specific class.
 
         :return: True if energey meter is available
                  False if energymeter is missing
         """
-        return SmartDevice.FEATURE_ENERGY_METER in self.features
+        raise NotImplementedError()
 
     @property
     def sys_info(self) -> Dict[str, Any]:

--- a/pyHS100/smartplug.py
+++ b/pyHS100/smartplug.py
@@ -81,6 +81,16 @@ class SmartPlug(SmartDevice):
             raise ValueError("State %s is not valid.", value)
 
     @property
+    def has_emeter(self):
+        """
+        Returns whether device has an energy meter.
+        :return: True if energy meter is available
+                 False otherwise
+        """
+        features = self.sys_info['feature'].split(':')
+        return SmartDevice.FEATURE_ENERGY_METER in features
+
+    @property
     def is_on(self) -> bool:
         """
         Returns whether device is on.


### PR DESCRIPTION
Consider `has_emeter` to be a part of the public API also in the future, the implementation specifics are moved into SmartPlug (as that of SmartBulb was already so). This is the last change I would like to get in before releasing 0.3.0.