### PR TITLE
Added transition period for SmartBulbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Turning led to True
 
 ## Bulb-specific commands
 
-At the moment setting brightness, color temperature and color (in HSV) is supported.
+At the moment setting brightness, color temperature and color (in HSV) is supported. You can also set transition period for instant or smooth fades
 The commands are straightforward, so feel free to check `--help` for instructions how to use them.
 
 **Feel free to submit patches as pull requests to add more functionality (e.g. scenes)!**
@@ -204,10 +204,10 @@ if bulb.is_variable_color_temp:
 
 ### Setting the color
 
-Hue is given in degrees (0-360) and saturation and value in percentage.
+Hue is given in degrees (0-360) and saturation and value in percentage. You can also add optional, fourth parameter - transition period (in milliseconds)
 
 ```python
 print(bulb.hsv)
 if bulb.is_color:
-   bulb.hsv = (180, 100, 100) # set to cyan
+   bulb.hsv = (180, 100, 100, 1000) # set to cyan, fade 1 second
 ```

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -16,7 +16,6 @@ from pyHS100 import (SmartDevice,
 
 pass_dev = click.make_pass_decorator(SmartDevice)
 
-
 @click.group(invoke_without_command=True)
 @click.option('--ip', envvar="PYHS100_IP", required=False)
 @click.option('--debug/--normal', default=False)
@@ -165,14 +164,15 @@ def temperature(dev, temperature):
 @click.argument("h", type=click.IntRange(0, 360), default=None)
 @click.argument("s", type=click.IntRange(0, 100), default=None)
 @click.argument("v", type=click.IntRange(0, 100), default=None)
+@click.argument("period", type=click.IntRange(0, 10000), default=500)
 @pass_dev
-def hsv(dev, h, s, v):
+def hsv(dev, h, s, v, period):
     """Get or set color in HSV. (Bulb only)"""
     if h is None or s is None or v is None:
         click.echo("Current HSV: %s" % dev.hsv)
     else:
         click.echo("Setting HSV: %s %s %s" % (h, s, v))
-        dev.hsv = (h, s, v)
+        dev.hsv = (h, s, v, period)
 
 
 @cli.command()

--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -112,21 +112,25 @@ class SmartBulb(SmartDevice):
         return hue, saturation, value
 
     @hsv.setter
-    def hsv(self, state: Tuple[int, int, int]):
+    def hsv(self, state: Tuple[int, int, int, int]):
         """
         Sets new HSV, if supported
 
-        :param tuple state: hue, saturation and value (degrees, %, %)
+        :param tuple state: hue, saturation, value and period (degrees, %, %, milliseconds)
         """
         if not self.is_color:
             return None
-
+        if(len(state)<=3):
+            period = 500
+        else:
+            period = state[3]
         light_state = {
             "hue": state[0],
             "saturation": state[1],
             "brightness": int(state[2] * 100 / 255),
-            "color_temp": 0
-            }
+            "color_temp": 0,
+            "transition_period":period
+        }
         self.set_light_state(light_state)
 
     @property


### PR DESCRIPTION
Changed HSV function for SmartBulbs - now user can set length of transition period (instant or very smooth change is now possible). JSON value "transition_period" is correctly interpreted by TP-Link bulbs.