### PR TITLE
Adds a Singleton class

### DIFF
--- a/pyHS100/singleton.py
+++ b/pyHS100/singleton.py
@@ -1,0 +1,33 @@
+
+class ArgsSingleton(type):
+    """
+    A metaclass which permits only a single instance of each derived class
+    sharing the same _class_name for any given set of positional 
+    arguments.
+
+    Attempts to instantiate a second instance of a derived class, or another
+    class with the same _class_name, with the same args will return the
+    existing instance.
+    """
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        key = getattr(cls, '_class_name', cls)
+        if key not in cls._instances:
+            cls._instances[key] = {}
+
+        if args not in cls._instances[key]:
+            cls._instances[key][args] = (
+                super(ArgsSingleton, cls).__call__(*args, **kwargs)
+            )
+
+        return cls._instances[key][args]
+
+
+class SmartDeviceSingletonBase(
+    ArgsSingleton(str('ArgsSingletonMeta'), (object,), {})
+):
+    """
+    The base class for the Device class.
+    """
+    pass

--- a/pyHS100/singleton.py
+++ b/pyHS100/singleton.py
@@ -2,12 +2,12 @@
 class ArgsSingleton(type):
     """
     A metaclass which permits only a single instance of each derived class
-    sharing the same _class_name for any given set of positional 
-    arguments.
+     sharing the same _class_name for any given set of positional
+     arguments.
 
     Attempts to instantiate a second instance of a derived class, or another
-    class with the same _class_name, with the same args will return the
-    existing instance.
+     class with the same _class_name, with the same args will return the
+     existing instance.
     """
     _instances = {}
 

--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -37,6 +37,7 @@ class SmartBulb(SmartDevice):
     and should be handled by the user of the library.
 
     """
+    _class_name = 'SmartBulb'
     # bulb states
     BULB_STATE_ON = 'ON'
     BULB_STATE_OFF = 'OFF'

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -49,7 +49,7 @@ class SmartDevice(SmartDeviceSingletonBase):
 
         :param str ip_address: ip address on which the device listens
         """
-        super(SmartDevice, self).__init__(ip_address, protocol)
+        super(SmartDevice, self).__init__()
         socket.inet_pton(socket.AF_INET, ip_address)
         self.ip_address = ip_address
         if not protocol:

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -19,6 +19,7 @@ import socket
 import warnings
 from collections import defaultdict
 from typing import Any, Dict, List, Tuple, Optional
+from pyHS100.singleton import SmartDeviceSingletonBase
 
 from .protocol import TPLinkSmartHomeProtocol
 
@@ -32,7 +33,8 @@ class SmartDeviceException(Exception):
     pass
 
 
-class SmartDevice(object):
+class SmartDevice(SmartDeviceSingletonBase):
+    _class_name = 'SmartDevice'
     # possible device features
     FEATURE_ENERGY_METER = 'ENE'
     FEATURE_TIMER = 'TIM'
@@ -47,6 +49,7 @@ class SmartDevice(object):
 
         :param str ip_address: ip address on which the device listens
         """
+        super(SmartDevice, self).__init__(ip_address, protocol)
         socket.inet_pton(socket.AF_INET, ip_address)
         self.ip_address = ip_address
         if not protocol:

--- a/pyHS100/smartplug.py
+++ b/pyHS100/smartplug.py
@@ -26,6 +26,7 @@ class SmartPlug(SmartDevice):
     Note:
     The library references the same structure as defined for the D-Link Switch
     """
+    _class_name = 'SmartPlug'
     # switch states
     SWITCH_STATE_ON = 'ON'
     SWITCH_STATE_OFF = 'OFF'


### PR DESCRIPTION
This update adds a singleton class so that only a single instance of a device can be created. the benifit to this would be if you connect to a device in on place in your code and you connect to the same device in a different place it does not create a new device instance, instead it returns the already created instance. It makes it easier for doing things like checking if new devices were added to the system. But now also offers the ability to cache specific data sets from the device and know that all stored instances of the device will contain the new cached data set.

I have not tested this code as I do not have a device yet. but I am hoping it should work properly. But i thought it might either spark an idea or maybe be useful
