### PR TITLE
Ability to Switch Bulb on to Specific Brightness/Color/Temperature

### DIFF
--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -122,6 +122,8 @@ class SmartBulb(SmartDevice):
             return None
 
         light_state = {
+            "on_off": 1,
+            "ignore_default": 1,
             "hue": state[0],
             "saturation": state[1],
             "brightness": int(state[2] * 100 / 255),
@@ -157,6 +159,8 @@ class SmartBulb(SmartDevice):
             return None
 
         light_state = {
+            "on_off": 1,
+            "ignore_default": 1,
             "color_temp": temp,
         }
         self.set_light_state(light_state)
@@ -189,6 +193,8 @@ class SmartBulb(SmartDevice):
             return None
 
         light_state = {
+            "on_off": 1,
+            "ignore_default": 1,
             "brightness": brightness,
         }
         self.set_light_state(light_state)


### PR DESCRIPTION
This Pull Request fixes an issue I came across where it was impossible to switch the LB130 on to a specific color, temperature or brightness instantly. Instead, the behaviour was for the default state of the light to come on, before changing to the desired brightness after a delay of about a second. This posed a problem in a project I worked on whereby the initial brightness would hurt the eyes of someone used to the dark, before the comfortable dim red light state became active.

It simply adds two lines to the `hsv`, `color_temp` and  `brightness` setters which tells the bulb to switch on if not already and to ignore the default state.