### PR TITLE
Use of alias instead of IP address or hostname

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -48,7 +48,11 @@ def cli(ctx, ip, host, alias, debug, bulb, plug):
         click.echo("Alias is given, using discovery to find host %s" %
                    alias)
         host = find_host_from_alias(alias=alias)
-        click.echo("Found hostname is {}".format(host))
+        if host:
+            click.echo("Found hostname is {}".format(host))
+        else:
+            click.echo("No device with name {} found".format(alias))
+            return
 
     if host is None:
         click.echo("No host name given, trying discovery..")

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -24,14 +24,14 @@ pass_dev = click.make_pass_decorator(SmartDevice)
               'instead.')
 @click.option('--host', envvar="PYHS100_HOST", required=False,
               help='The host name or IP address of the device to connect to.')
-@click.option('--devicename', envvar="PYHS100_NAME", required=False,
-              help='The device name of the device to connect to.')
+@click.option('--alias', envvar="PYHS100_NAME", required=False,
+              help='The device name, or alias, of the device to connect to.')
 
 @click.option('--debug/--normal', default=False)
 @click.option('--bulb', default=False, is_flag=True)
 @click.option('--plug', default=False, is_flag=True)
 @click.pass_context
-def cli(ctx, ip, host, devicename, debug, bulb, plug):
+def cli(ctx, ip, host, alias, debug, bulb, plug):
     """A cli tool for controlling TP-Link smart home plugs."""
     if debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -44,10 +44,10 @@ def cli(ctx, ip, host, devicename, debug, bulb, plug):
     if ip is not None and host is None:
         host = ip
 
-    if devicename is not None and host is None:
-        click.echo("Device name is given, using discovery to find host %s" %
-                   devicename)
-        host = find_host_from_device_name(devicename=devicename)
+    if alias is not None and host is None:
+        click.echo("Alias is given, using discovery to find host %s" %
+                   alias)
+        host = find_host_from_alias(alias=alias)
         print("Found hostname is {}".format(host))
 
 
@@ -89,16 +89,16 @@ def discover(ctx, timeout, discover_only):
     return found_devs
 
 
-def find_host_from_device_name(devicename, timeout=1, attempts=3):
-    """Discover a device identified by its devicename"""
+def find_host_from_alias(alias, timeout=1, attempts=3):
+    """Discover a device identified by its alias"""
     host = None
     click.echo("Trying to discover %s using %s attempts of %s seconds" %
-               (devicename, attempts, timeout))
+               (alias, attempts, timeout))
     for attempt in range(1, attempts):
         print("Attempt %s of %s" % (attempt, attempts))
         found_devs = Discover.discover(timeout=timeout).items()
         for _, dev in found_devs:
-            if dev.alias.lower() == devicename.lower():
+            if dev.alias.lower() == alias.lower():
                 host = dev.host
                 return host
     return None

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -48,8 +48,7 @@ def cli(ctx, ip, host, alias, debug, bulb, plug):
         click.echo("Alias is given, using discovery to find host %s" %
                    alias)
         host = find_host_from_alias(alias=alias)
-        print("Found hostname is {}".format(host))
-
+        click.echo("Found hostname is {}".format(host))
 
     if host is None:
         click.echo("No host name given, trying discovery..")
@@ -81,7 +80,7 @@ def discover(ctx, timeout, discover_only):
     click.echo("Discovering devices for %s seconds" % timeout)
     found_devs = Discover.discover(timeout=timeout).items()
     if not discover_only:
-        for _, dev in found_devs:
+        for ip, dev in found_devs:
             ctx.obj = dev
             ctx.invoke(state)
             print()
@@ -95,13 +94,14 @@ def find_host_from_alias(alias, timeout=1, attempts=3):
     click.echo("Trying to discover %s using %s attempts of %s seconds" %
                (alias, attempts, timeout))
     for attempt in range(1, attempts):
-        print("Attempt %s of %s" % (attempt, attempts))
+        click.echo("Attempt %s of %s" % (attempt, attempts))
         found_devs = Discover.discover(timeout=timeout).items()
-        for _, dev in found_devs:
+        for ip, dev in found_devs:
             if dev.alias.lower() == alias.lower():
                 host = dev.host
                 return host
     return None
+
 
 @cli.command()
 @pass_dev

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -47,7 +47,7 @@ def cli(ctx, ip, host, devicename, debug, bulb, plug):
     if devicename is not None and host is None:
         click.echo("Device name is given, using discovery to find host %s" %
                    devicename)
-        host = ctx.invoke(find_host_from_device_name, devicename=devicename)
+        host = find_host_from_device_name(devicename=devicename)
         print("Found hostname is {}".format(host))
 
 
@@ -89,13 +89,8 @@ def discover(ctx, timeout, discover_only):
     return found_devs
 
 
-@cli.command()
-@click.option('--timeout', default=3, required=False)
-@click.option('--attempts', default=10, required=False)
-@click.option('--devicename', required=True)
-@click.pass_context
-def find_host_from_device_name(ctx, timeout, attempts, devicename):
-    """Discover devices in the network."""
+def find_host_from_device_name(devicename, timeout=1, attempts=3):
+    """Discover a device identified by its devicename"""
     host = None
     click.echo("Trying to discover %s using %s attempts of %s seconds" %
                (devicename, attempts, timeout))

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -81,7 +81,7 @@ def discover(ctx, timeout, discover_only):
     click.echo("Discovering devices for %s seconds" % timeout)
     found_devs = Discover.discover(timeout=timeout).items()
     if not discover_only:
-        for ip, dev in found_devs:
+        for _, dev in found_devs:
             ctx.obj = dev
             ctx.invoke(state)
             print()
@@ -102,7 +102,7 @@ def find_host_from_device_name(ctx, timeout, attempts, devicename):
     for attempt in range(1, attempts):
         print("Attempt %s of %s" % (attempt, attempts))
         found_devs = Discover.discover(timeout=timeout).items()
-        for ip, dev in found_devs:
+        for _, dev in found_devs:
             if dev.alias.lower() == devicename.lower():
                 host = dev.host
                 return host


### PR DESCRIPTION
Some people will have a network where TP-link devices like power plugs do not have a static ip-address and do not have the luxury of a hostname. In this case eacht TP-link device has a device name, or alias. This can be used to identify the smart plugs and bulbs uniquely. Using the parameter
--alias
instead of --ip or --hostname, the cli will attempt to discover a device with this alias (case insensitive). Upon finding such a device, it will use this device, e.g. `cli.py --alias kalle --plug off` will switch a smart plug with the alias "Kalle" or "kalle" off.
`cli.py --alias "kalle" --plug on` will switch the device on again. A little bit confusing will be
`cli.py --alias "kalle" alias "kalle anka"` which will change the device name, alias, of a device with the alias "kalle". The new alias will be "kalle anka". When undesired, this can be circumvented by:

- changing `--ip`, `--hostname` or `--alias` into `--byip`, `--byhostname` or `--byalias`
- changing `alias` as parameter into e.g. `device`
- proper documentation