### PR TITLE
Add reboot command to restart the device

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -255,5 +255,13 @@ def off(plug):
     plug.turn_off()
 
 
+@cli.command()
+@click.option("--delay", default=1)
+@pass_dev
+def reboot(plug, delay):
+    """Reboot the device."""
+    click.echo("Rebooting the device..")
+    plug.reboot(delay)
+
 if __name__ == "__main__":
     cli()

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -513,6 +513,17 @@ class SmartDevice(object):
         response = EmeterStatus(self.get_emeter_realtime())
         return response['power']
 
+    def reboot(self, delay=1) -> None:
+        """
+        Reboot the device.
+
+        :param delay: Delay the reboot for `delay` seconds.
+        :return: None
+
+        Note that giving a delay of zero causes this to block.
+        """
+        self._query_helper("system", "reboot", {"delay": delay})
+
     def turn_off(self) -> None:
         """
         Turns the device off.


### PR DESCRIPTION
Add reboot command. Takes delay (defaulting to 1) for how long to wait before doing the reboot. Setting this to 0 causes an instant reboot with no response from the device, causing an exception being thrown.

```
Usage: pyhs100 reboot [OPTIONS]

  Reboot the device.

Options:
  --delay INTEGER
  --help           Show this message and exit.
```

Fixes #111