### PR TITLE
avoid 'referenced before assignment' exception

### DIFF
--- a/pyHS100/protocol.py
+++ b/pyHS100/protocol.py
@@ -42,6 +42,7 @@ class TPLinkSmartHomeProtocol:
             request = json.dumps(request)
 
         timeout = TPLinkSmartHomeProtocol.DEFAULT_TIMEOUT
+        sock = None
         try:
             sock = socket.create_connection((host, port), timeout)
 
@@ -63,14 +64,17 @@ class TPLinkSmartHomeProtocol:
 
         finally:
             try:
-                sock.shutdown(socket.SHUT_RDWR)
+                if sock:
+                    sock.shutdown(socket.SHUT_RDWR)
             except OSError:
                 # OSX raises OSError when shutdown() gets called on a closed
                 # socket. We ignore it here as the data has already been read
                 # into the buffer at this point.
                 pass
+
             finally:
-                sock.close()
+                if sock:
+                    sock.close()
 
         response = TPLinkSmartHomeProtocol.decrypt(buffer[4:])
         _LOGGER.debug("< (%i) %s", len(response), response)


### PR DESCRIPTION
On occasion I see connectivity issues which triggers exceptions on socket.create_connection failing and then trying to call close() on sock.