### PR TITLE
Smartstrip: return on_since state information only when the socket is on

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -132,7 +132,7 @@ def state(ctx, dev):
     if dev.num_children > 0:
         is_on = dev.is_on()
         aliases = dev.get_alias()
-        for child in dev.num_children:
+        for child in range(dev.num_children):
             click.echo(
                 click.style("  * %s state: %s" %
                             (aliases[child],

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -129,6 +129,15 @@ def state(ctx, dev):
 
     click.echo(click.style("Device state: %s" % "ON" if dev.is_on else "OFF",
                            fg="green" if dev.is_on else "red"))
+    if dev.num_children > 0:
+        is_on = dev.is_on()
+        aliases = dev.get_alias()
+        for child in dev.num_children:
+            click.echo(
+                click.style("  * %s state: %s" %
+                            (aliases[child],
+                             "ON" if is_on[child] else "OFF"),
+                            fg="green" if is_on[child] else "red"))
     click.echo("Host/IP: %s" % dev.host)
     for k, v in dev.state_information.items():
         click.echo("%s: %s" % (k, v))

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -88,6 +88,7 @@ class SmartDevice(object):
         self.protocol = protocol
         self.emeter_type = "emeter"  # type: str
         self.context = context
+        self.num_children = 0
 
     def _query_helper(self,
                       target: str,

--- a/pyHS100/smartstrip.py
+++ b/pyHS100/smartstrip.py
@@ -209,8 +209,7 @@ class SmartStrip(SmartPlug):
             plug_number = plug_index + 1
             if is_on[plug_index]:
                 state['Plug %d on since' % plug_number] = on_since[plug_index]
-            else:
-                state['Plug %d state' % plug_number] = self.SWITCH_STATE_OFF
+
         return state
 
     def get_emeter_realtime(self, *, index: int = -1) -> Optional[Any]:

--- a/pyHS100/smartstrip.py
+++ b/pyHS100/smartstrip.py
@@ -204,8 +204,13 @@ class SmartStrip(SmartPlug):
         """
         state = {'LED state': self.led}
         on_since = self.on_since()
+        is_on = self.is_on()
         for plug_index in range(self.num_children):
-            state['Plug %d on since' % (plug_index + 1)] = on_since[plug_index]
+            plug_number = plug_index + 1
+            if is_on[plug_index]:
+                state['Plug %d on since' % plug_number] = on_since[plug_index]
+            else:
+                state['Plug %d state' % plug_number] = self.SWITCH_STATE_OFF
         return state
 
     def get_emeter_realtime(self, *, index: int = -1) -> Optional[Any]:


### PR DESCRIPTION
`on_since` information is added to the state attributes only when the socket is on.
This PR also includes adding proper cli printouts for the child sockets.

Fixes #160 