### PR TITLE
Check for errors also in the command payload

### DIFF
--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -125,13 +125,18 @@ class SmartDevice(object):
 
         result = response[target]
         if "err_code" in result and result["err_code"] != 0:
-            raise SmartDeviceException("Error on {}.{}: {}"
+            raise SmartDeviceException("Error on {} {}: {}"
                                        .format(target, cmd, result))
 
         if cmd not in result:
             raise SmartDeviceException("No command in response: {}"
                                        .format(response))
+
         result = result[cmd]
+        if "err_code" in result and result["err_code"] != 0:
+            raise SmartDeviceException("Error on {} {}: {}"
+                                       .format(target, cmd, result))
+
         del result["err_code"]
 
         return result


### PR DESCRIPTION
For example, trying to set unsupported color temperature will cause such response.
This gets ignored at the moment completely, so there is no indication at all why the command caused no effect on the device.

```
> (93) {"smartlife.iot.smartbulb.lightingservice": {"transition_light_state": {"color_temp": 6000}}}
< (125) {"smartlife.iot.smartbulb.lightingservice":{"transition_light_state":{"err_code":-10000,"err_msg":"Invalid input argument"}}}
```

In comparison, this is an error reported when unavailable module is being accessed:
```
DEBUG:pyHS100.protocol:> (28) {"time": {"get_time": null}}
DEBUG:pyHS100.protocol:< (58) {"time":{"err_code":-2001,"err_msg":"Module not support"}}
```