### PR TITLE
Specify broadcast address for discovery

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -40,12 +40,17 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     required=False,
     help="The device name, or alias, of the device to connect to.",
 )
+@click.option(
+    "--target", 
+    default="255.255.255.255", required=False,
+    help="The broadcast address to be used for discovery.",
+)
 @click.option("--debug/--normal", default=False)
 @click.option("--bulb", default=False, is_flag=True)
 @click.option("--plug", default=False, is_flag=True)
 @click.option("--strip", default=False, is_flag=True)
 @click.pass_context
-def cli(ctx, ip, host, alias, debug, bulb, plug, strip):
+def cli(ctx, ip, host, alias, target, debug, bulb, plug, strip):
     """A cli tool for controlling TP-Link smart home plugs."""
     if debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -60,7 +65,7 @@ def cli(ctx, ip, host, alias, debug, bulb, plug, strip):
 
     if alias is not None and host is None:
         click.echo("Alias is given, using discovery to find host %s" % alias)
-        host = find_host_from_alias(alias=alias)
+        host = find_host_from_alias(alias=alias, target=target)
         if host:
             click.echo("Found hostname is {}".format(host))
         else:
@@ -92,8 +97,10 @@ def cli(ctx, ip, host, alias, debug, bulb, plug, strip):
 
 @cli.command()
 @click.option("--save")
-def dump_discover(save):
-    for dev in Discover.discover(return_raw=True).values():
+@click.pass_context
+def dump_discover(ctx, save):
+    target = ctx.params['target']
+    for dev in Discover.discover(target=target, return_raw=True).values():
         model = dev["system"]["get_sysinfo"]["model"]
         hw_version = dev["system"]["get_sysinfo"]["hw_ver"]
         save_to = "%s_%s.json" % (model, hw_version)
@@ -111,8 +118,9 @@ def dump_discover(save):
 @click.pass_context
 def discover(ctx, timeout, discover_only, dump_raw):
     """Discover devices in the network."""
+    target = ctx.params['target']
     click.echo("Discovering devices for %s seconds" % timeout)
-    found_devs = Discover.discover(timeout=timeout, return_raw=dump_raw).items()
+    found_devs = Discover.discover(target=target, timeout=timeout, return_raw=dump_raw).items()
     if not discover_only:
         for ip, dev in found_devs:
             if dump_raw:
@@ -125,7 +133,7 @@ def discover(ctx, timeout, discover_only, dump_raw):
     return found_devs
 
 
-def find_host_from_alias(alias, timeout=1, attempts=3):
+def find_host_from_alias(alias, target='255.255.255.255', timeout=1, attempts=3):
     """Discover a device identified by its alias."""
     host = None
     click.echo(
@@ -134,7 +142,7 @@ def find_host_from_alias(alias, timeout=1, attempts=3):
     )
     for attempt in range(1, attempts):
         click.echo("Attempt %s of %s" % (attempt, attempts))
-        found_devs = Discover.discover(timeout=timeout).items()
+        found_devs = Discover.discover(target=target, timeout=timeout).items()
         for ip, dev in found_devs:
             if dev.alias.lower() == alias.lower():
                 host = dev.host

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -41,7 +41,7 @@ pass_dev = click.make_pass_decorator(SmartDevice)
     help="The device name, or alias, of the device to connect to.",
 )
 @click.option(
-    "--target", 
+    "--target",
     default="255.255.255.255", required=False,
     help="The broadcast address to be used for discovery.",
 )

--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -99,7 +99,7 @@ def cli(ctx, ip, host, alias, target, debug, bulb, plug, strip):
 @click.option("--save")
 @click.pass_context
 def dump_discover(ctx, save):
-    target = ctx.params['target']
+    target = ctx.parent.params['target']
     for dev in Discover.discover(target=target, return_raw=True).values():
         model = dev["system"]["get_sysinfo"]["model"]
         hw_version = dev["system"]["get_sysinfo"]["hw_ver"]
@@ -118,7 +118,7 @@ def dump_discover(ctx, save):
 @click.pass_context
 def discover(ctx, timeout, discover_only, dump_raw):
     """Discover devices in the network."""
-    target = ctx.params['target']
+    target = ctx.parent.params['target']
     click.echo("Discovering devices for %s seconds" % timeout)
     found_devs = Discover.discover(target=target, timeout=timeout, return_raw=dump_raw).items()
     if not discover_only:

--- a/pyHS100/discover.py
+++ b/pyHS100/discover.py
@@ -65,8 +65,6 @@ class Discover:
         if protocol is None:
             protocol = TPLinkSmartHomeProtocol()
 
-        #target = "255.255.255.255"
-
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/pyHS100/discover.py
+++ b/pyHS100/discover.py
@@ -43,6 +43,7 @@ class Discover:
     @staticmethod
     def discover(
         protocol: TPLinkSmartHomeProtocol = None,
+        target: str = "255.255.255.255",
         port: int = 9999,
         timeout: int = 3,
         discovery_packets=3,
@@ -55,6 +56,7 @@ class Discover:
         and waits for given timeout for answers from devices.
 
         :param protocol: Protocol implementation to use
+        :param target: The target broadcast address (e.g. 192.168.xxx.255).
         :param timeout: How long to wait for responses, defaults to 3
         :param port: port to send broadcast messages, defaults to 9999.
         :rtype: dict
@@ -63,7 +65,7 @@ class Discover:
         if protocol is None:
             protocol = TPLinkSmartHomeProtocol()
 
-        target = "255.255.255.255"
+        #target = "255.255.255.255"
 
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)


### PR DESCRIPTION
Sometimes it's useful to be able to specify the broadcast address for discovery. On a host with multiple network interfaces, when a discovery message is sent to 255.255.255.255:9999, the routing table decides which interface it is routed to. By specifying broadcast address, e.g. 192.168.xxx.255, the discovery message can be directed to a particular subnet only.

The modification to discover.py is very limited and shouldn't affect existing programs using the library. The cli.py is changed to include a --target option for specifying broadcast address.