### PR TITLE
Fix CLI for HS300

### DIFF
--- a/pyHS100/cli.py
+++ b/pyHS100/cli.py
@@ -164,7 +164,7 @@ def state(ctx, dev):
         )
     )
     if dev.num_children > 0:
-        is_on = dev.is_on()
+        is_on = dev.get_is_on()
         aliases = dev.get_alias()
         for child in range(dev.num_children):
             click.echo(


### PR DESCRIPTION
 The array of on states is returned by get_is_on, not is_on
Before this change, running discover will give:
  File "cli.py", line 167, in state
    is_on = dev.is_on()
TypeError: 'bool' object is not callable

This is because is_on is a property.
If you use is_on here, it crashes a few lines later anyway because it indexes into it expecting it to be an array.
Which is what get_is_on returns.

With this change, everything works in discover.