### PR TITLE
Fix __repr__ function of SmartDevice

### DIFF
--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -616,7 +616,7 @@ class SmartDevice:
         is_on = self.is_on
         if callable(is_on):
             is_on = is_on()
-        return "<%s at %s (%s), is_on: %s - dev specific: %s>" % (
+        return "<%s model %s at %s (%s), is_on: %s - dev specific: %s>" % (
             self.__class__.__name__,
             self.model,
             self.host,

--- a/pyHS100/tests/test_fixtures.py
+++ b/pyHS100/tests/test_fixtures.py
@@ -654,3 +654,10 @@ def test_cache_invalidates(dev):
         dev.get_sysinfo()
         assert query_mock.call_count == 2
         # assert query_mock.called_once()
+
+
+def test_representation(dev):
+    import re
+    pattern = re.compile("<.* model .* at .* (.*), is_on: .* - dev specific: .*>")
+    assert pattern.match(str(dev))
+


### PR DESCRIPTION
The following fails due to __repr__ function on the device is missing… a format parameter. This adds in a test and fixes the bug

for dev in Discover.discover().values():
    print(dev)