### PR TITLE
Python < 3.5 cleanups

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(name='pyHS100',
       author_email='sean@gadgetreactor.com',
       license='GPLv3',
       packages=['pyHS100'],
-      install_requires=['click', 'typing', 'deprecation'],
+      install_requires=['click', 'deprecation'],
       python_requires='>=3.5',
       entry_points={
             'console_scripts': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,8 @@
 [tox]
-envlist=py33,py34,py35,py36,py37,flake8
+envlist=py35,py36,py37,flake8
 skip_missing_interpreters = True
 
 [tox:travis]
-3.3 = py33
-3.4 = py34
 3.5 = py35
 3.6 = py36
 3.7 = py37


### PR DESCRIPTION
Python 3.5 is said to be the minimum version, so clean up things that are there for earlier versions.