### PR TITLE
Updates and bugfixes for KL130

### DIFF
--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -66,6 +66,7 @@ class SmartBulb(SmartDevice):
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
     EMETER_SERVICE = "smartlife.iot.common.emeter"
     CLOUD_SERVICE = "smartlife.iot.common.cloud"
+    TIME_SERVICE = "smartlife.iot.common.timesetting"
     SYSTEM_ALT_SERVICE = "smartlife.iot.common.system"
     SYSTEM_ALT_COMMAND = "get_details"
 

--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -60,6 +60,7 @@ class SmartBulb(SmartDevice):
     """
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
+    EMETER_SERVICE = "smartlife.iot.common.emeter"
 
     def __init__(
         self,
@@ -71,7 +72,6 @@ class SmartBulb(SmartDevice):
         SmartDevice.__init__(
             self, host=host, protocol=protocol, context=context, cache_ttl=cache_ttl
         )
-        self.emeter_type = "smartlife.iot.common.emeter"
         self._device_type = DeviceType.Bulb
 
     @property

--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -61,6 +61,9 @@ class SmartBulb(SmartDevice):
 
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
     EMETER_SERVICE = "smartlife.iot.common.emeter"
+    CLOUD_SERVICE = "smartlife.iot.common.cloud"
+    SYSTEM_ALT_SERVICE = "smartlife.iot.common.system"
+    SYSTEM_ALT_COMMAND = "get_details"
 
     def __init__(
         self,

--- a/pyHS100/smartbulb.py
+++ b/pyHS100/smartbulb.py
@@ -59,6 +59,10 @@ class SmartBulb(SmartDevice):
     and should be handled by the user of the library.
     """
 
+    # Override some service names.
+    # These were taken from a KL130. Your device may be
+    # slightly different.
+
     LIGHT_SERVICE = "smartlife.iot.smartbulb.lightingservice"
     EMETER_SERVICE = "smartlife.iot.common.emeter"
     CLOUD_SERVICE = "smartlife.iot.common.cloud"

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -333,7 +333,7 @@ class SmartDevice:
 
         return self._query_helper(self.NETIF_SERVICE, "get_stainfo")
 
-    def set_wifi(self, ssid: str, password: str, key_type: int=3) -> None:
+    def set_wifi(self, ssid: str, password: str, key_type: int = 3) -> None:
         """Set the wireless network that the device will use.
 
         This command will allow you to provision a factory-

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -86,6 +86,9 @@ class SmartDevice:
     STATE_ON = "ON"
     STATE_OFF = "OFF"
 
+    # Subclasses may override these strings if their device
+    # uses different service names.
+
     SYSTEM_SERVICE = "system"
     # On newer devices, there are two services for "system" commands.
     SYSTEM_ALT_SERVICE = "system"

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -330,7 +330,7 @@ class SmartDevice:
 
         return self._query_helper(self.NETIF_SERVICE, "get_stainfo")
 
-    def set_wifi(self, ssid, password, key_type=3) -> None:
+    def set_wifi(self, ssid: str, password: str, key_type: int=3) -> None:
         """Set the wireless network that the device will use.
 
         This command will allow you to provision a factory-

--- a/pyHS100/smartdevice.py
+++ b/pyHS100/smartdevice.py
@@ -288,6 +288,35 @@ class SmartDevice:
         # self.initialize()
 
     @property
+    def wifi(self) -> Dict:
+        """Return information about the wifi network that
+        this device is connected to.
+
+        :return: A dictionary containing the keys "ssid",
+                 "key_type", and "rssi"
+        :rtype: dict
+        :raises SmartDeviceException: on error
+        """
+
+        return self._query_helper("netif", "get_stainfo")
+
+    def set_wifi(self, ssid, password, key_type=3) -> None:
+        """Set the wireless network that the device will use.
+
+        This command will allow you to provision a factory-
+        fresh device without ever connecting through the
+        app.
+
+        :param ssid: SSID (name) of the network
+        :param password: The password to join the network
+        :param key_type: What kind of security to use
+                         (default=3 for WPA2)
+        :raises SmartDeviceException: on error
+        """
+
+        self._query_helper("netif", "set_stainfo", {"ssid": ssid, "password": password, "key_type": key_type})
+
+    @property
     def time(self) -> Optional[datetime]:
         """Return current time from the device.
 

--- a/pyHS100/smartplug.py
+++ b/pyHS100/smartplug.py
@@ -27,6 +27,8 @@ class SmartPlug(SmartDevice):
     and should be handled by the user of the library.
     """
 
+    DIMMER_SERVICE = "smartlife.iot.dimmer"
+
     def __init__(
         self,
         host: str,
@@ -110,7 +112,7 @@ class SmartPlug(SmartDevice):
         elif 0 < value <= 100:
             self.turn_on()
             self._query_helper(
-                "smartlife.iot.dimmer", "set_brightness", {"brightness": value}
+                self.DIMMER_SERVICE, "set_brightness", {"brightness": value}
             )
         else:
             raise ValueError("Brightness value %s is not valid." % value)
@@ -147,14 +149,14 @@ class SmartPlug(SmartDevice):
 
         :raises SmartDeviceException: on error
         """
-        self._query_helper("system", "set_relay_state", {"state": 1})
+        self._query_helper(self.SYSTEM_SERVICE, "set_relay_state", {"state": 1})
 
     def turn_off(self):
         """Turn the switch off.
 
         :raises SmartDeviceException: on error
         """
-        self._query_helper("system", "set_relay_state", {"state": 0})
+        self._query_helper(self.SYSTEM_SERVICE, "set_relay_state", {"state": 0})
 
     @property
     def led(self) -> bool:
@@ -176,7 +178,7 @@ class SmartPlug(SmartDevice):
         :param bool state: True to set led on, False to set led off
         :raises SmartDeviceException: on error
         """
-        self._query_helper("system", "set_led_off", {"off": int(not state)})
+        self._query_helper(self.SYSTEM_SERVICE, "set_led_off", {"off": int(not state)})
 
     @property
     def on_since(self) -> datetime.datetime:


### PR DESCRIPTION
This pull request adds several features:

- Commands to get and set wifi network (useful for initial provisioning without app)
- Commands to get cloud info and disable cloud connectivity (for privacy)
- Command to set location

It also fixes the following problems with my KL130:

- Set alias does not work
- Get location does not work
- Get time does not work

I put these changes into the `SmartBulb` class, assuming all bulbs are like my KL130. If that is not the case, it may break these commands. I don't have a way to test other devices. The SmartPlugs should be unaffected by these changes (other than adding new commands.)