### PR TITLE
Removes emeter discovery

### DIFF
--- a/pyHS100/discover.py
+++ b/pyHS100/discover.py
@@ -10,8 +10,7 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class Discover:
-    DISCOVERY_QUERY = {"system": {"get_sysinfo": None},
-                       "emeter": {"get_realtime": None}}
+    DISCOVERY_QUERY = {"system": {"get_sysinfo": None}}
 
     @staticmethod
     def discover(protocol: TPLinkSmartHomeProtocol = None,


### PR DESCRIPTION
This caused interoperatbility isssues with newer HS220 hardware.
Removing this has fixed it for several folks.

See https://github.com/home-assistant/core/issues/39395