### PR TITLE
Prepare 0.3.5.2 - goodbye, goodbye release

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,28 @@
 Changelog
 =========
 
+0.3.5.2 (2020-11-24)
+------------
+
+- Removes emeter discovery (#197) [bmbouter]
+
+  This caused interoperatbility isssues with newer HS220 hardware.
+  Removing this has fixed it for several folks.
+
+  See https://github.com/home-assistant/core/issues/39395
+
+
+0.3.5.1 (2020-07-11)
+------------
+
+This release was done to drop the typing from install_requires.
+
+- Prepare the goodbye release: 0.3.5.1. [Teemu Rytilahti]
+
+  * update the shipped README to include the location of the follow up project
+  * remove typing from dependencies, fixes https://github.com/home-assistant/core/pull/37707
+
+
 0.3.5 (2019-04-13)
 ------------
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 **This project is not updated anymore and should be considered abandoned.
+The last released pypi version is in the `goodbye_release` branch.
 Future developments will be done in asyncio-using fork, [python-kasa](https://github.com/python-kasa/python-kasa).**
 
 # pyHS100

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pyHS100',
-      version='0.3.5.1',
+      version='0.3.5.2',
       description='Interface for TPLink HS1xx plugs, HS2xx wall switches & LB1xx bulbs',
       url='https://github.com/GadgetReactor/pyHS100',
       author='Sean Seah (GadgetReactor)',


### PR DESCRIPTION
This release provides a quick fix solution for some HS220 users (python-kasa issue on this matter: https://github.com/python-kasa/python-kasa/issues/105) until python-kasa is ready enough for homeassistant inclusion.

* Update CHANGELOG to contain the release information
* Add a note that the `master` is not the branch that contains the newest release.

This is just to fix https://github.com/home-assistant/core/issues/39395 considering the minimal change for potentially happier users – this project remains still otherwise unmaintained and there are no plans for further releases.